### PR TITLE
fix: UINavigationBarAppearance support for iOS15

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,25 @@
 MIT License
 
+Copyright (c) 2022 StephenFang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 Copyright (c) 2021 Related Code
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/PasscodeKit/Sources/PasscodeInterval.swift
+++ b/PasscodeKit/Sources/PasscodeInterval.swift
@@ -26,3 +26,60 @@ enum PasscodeInterval: Double, CaseIterable {
         }
     }
 }
+
+class PasscodeKitInterval: UIViewController {
+    
+    fileprivate let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    fileprivate var selectedRow = 0
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = "Require Password"
+        
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
+        
+        view.addSubview(tableView)
+        tableView.frame = view.bounds
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if let selectedRow = PasscodeInterval.allCases.firstIndex(where: { $0.rawValue == PasscodeKit.passcodeInterval()
+        }) {
+            self.selectedRow = selectedRow
+        }
+        tableView.selectRow(at: IndexPath(item: selectedRow, section: 0), animated: false, scrollPosition: .top)
+    }
+}
+
+extension IntervalViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return PasscodeInterval.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        var cell: UITableViewCell! = tableView.dequeueReusableCell(withIdentifier: "cell")
+        if (cell == nil) { cell = UITableViewCell(style: .default, reuseIdentifier: "cell") }
+
+        cell.selectionStyle = .none
+        cell.textLabel?.text = PasscodeInterval.allCases[indexPath.item].localizedDescription
+        cell.accessoryType = indexPath.row == selectedRow ? .checkmark : .none
+
+        return cell
+    }
+}
+
+extension IntervalViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        PasscodeKit.passcodeInterval(PasscodeInterval.allCases[indexPath.item].rawValue)
+        
+        selectedRow = indexPath.row
+        tableView.reloadData()
+    }
+}

--- a/PasscodeKit/Sources/PasscodeInterval.swift
+++ b/PasscodeKit/Sources/PasscodeInterval.swift
@@ -1,0 +1,28 @@
+//
+//  PasscodeInterval.swift
+//  app
+//
+//  Created by StephenFang on 2022/7/16.
+//  Copyright © 2022 KZ. All rights reserved.
+//
+
+import Foundation
+
+enum PasscodeInterval: Double, CaseIterable {
+    case immediately  = 0.0
+    case oneMinute    = 1.0
+    case fiveMinutes  = 5.0
+    case tenMinutes   = 10.0
+    case halfAnHour   = 30.0
+    case anHour       = 60.0
+    
+    var localizedDescription: String {
+        if self == .immediately {
+            return PasscodeKit.vefifyPasscodeImmediately
+        } else if self == .anHour {
+            return PasscodeKit.vefifyPasscodeAfterOneHour
+        } else {
+            return String(format: PasscodeKit.vefifyPasscodeAfterMinutes, rawValue)
+        }
+    }
+}

--- a/PasscodeKit/Sources/PasscodeKit.swift
+++ b/PasscodeKit/Sources/PasscodeKit.swift
@@ -294,9 +294,15 @@ extension PasscodeKit {
     }
     
     //-------------------------------------------------------------------------------------------------------------------------------------------
-    public class func verifiedTimeInterval() -> TimeInterval {
+    public class func passcodeLocalizedInterval() -> String {
+        return PasscodeInterval.allCases.first(where: { $0.rawValue == PasscodeKit.passcodeInterval()})?.localizedDescription ?? PasscodeKit.vefifyPasscodeImmediately
+    }
+    
+    //-------------------------------------------------------------------------------------------------------------------------------------------
+    public class func verifiedTimeInterval() -> Double {
         return UserDefaults.standard.double(forKey: "PasscodeVerifiedInterval")
     }
+    
     
     //-------------------------------------------------------------------------------------------------------------------------------------------
     public class func verifiedTimeInterval(_ date: Date) {

--- a/PasscodeKit/Sources/PasscodeKit.swift
+++ b/PasscodeKit/Sources/PasscodeKit.swift
@@ -22,6 +22,8 @@ import CryptoKit
 	@objc optional func passcodeCheckedButDisabled()
 	@objc optional func passcodeEnteredSuccessfully()
 	@objc optional func passcodeMaximumFailedAttempts()
+    
+    @objc optional func passcodeIntervalChanged()
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------------
@@ -152,10 +154,10 @@ extension PasscodeKit {
 		var result = true
 		if let navigationController = viewController as? UINavigationController {
 			if let presentedView = navigationController.viewControllers.first {
-				if (presentedView is PasscodeKitCreate)	{ result = false }
-				if (presentedView is PasscodeKitChange)	{ result = false }
-				if (presentedView is PasscodeKitRemove)	{ result = false }
-				if (presentedView is PasscodeKitVerify)	{ result = false }
+				if (presentedView is PasscodeKitCreate)	  { result = false }
+				if (presentedView is PasscodeKitChange)	  { result = false }
+				if (presentedView is PasscodeKitRemove)	  { result = false }
+				if (presentedView is PasscodeKitVerify)	  { result = false }
 			}
 		}
 		return result
@@ -209,6 +211,14 @@ extension PasscodeKit {
 		let navController = PasscodeKitNavController(rootViewController: passcodeKitRemove)
 		viewController.present(navController, animated: true)
 	}
+    
+    //-------------------------------------------------------------------------------------------------------------------------------------------
+    public class func changeInterval(_ viewController: UINavigationController) {
+
+        let passcodeKitInterval = PasscodeKitInterval()
+        passcodeKitInterval.delegate = viewController as? PasscodeKitDelegate
+        viewController.pushViewController(passcodeKitInterval, animated: true)
+    }
 }
 
 // MARK: - Passcode methods

--- a/PasscodeKit/Sources/PasscodeKit.swift
+++ b/PasscodeKit/Sources/PasscodeKit.swift
@@ -268,8 +268,16 @@ class PasscodeKitNavController: UINavigationController {
 			self.isModalInPresentation = true
 			self.modalPresentationStyle = .fullScreen
 		}
-
-		navigationBar.isTranslucent = false
+        
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+            UINavigationBar.appearance().compactAppearance = appearance
+        } else {
+            navigationBar.isTranslucent = false
+        }
 	}
 
 	//-------------------------------------------------------------------------------------------------------------------------------------------

--- a/PasscodeKit/Sources/PasscodeKitInterval.swift
+++ b/PasscodeKit/Sources/PasscodeKitInterval.swift
@@ -1,17 +1,39 @@
 //
-//  IntervalViewController.swift
-//  Example
+//  PasscodeInterval.swift
+//  app
 //
-//  Created by StephenFang on 2022/7/8.
+//  Created by StephenFang on 2022/7/16.
 //  Copyright © 2022 KZ. All rights reserved.
 //
 
 import UIKit
 
-class IntervalViewController: UIViewController {
+enum PasscodeInterval: Double, CaseIterable {
+    case immediately  = 0.0
+    case oneMinute    = 1.0
+    case fiveMinutes  = 5.0
+    case tenMinutes   = 10.0
+    case halfAnHour   = 30.0
+    case anHour       = 60.0
+    
+    var localizedDescription: String {
+        if self == .immediately {
+            return PasscodeKit.vefifyPasscodeImmediately
+        } else if self == .anHour {
+            return PasscodeKit.vefifyPasscodeAfterOneHour
+        } else {
+            return String(format: PasscodeKit.vefifyPasscodeAfterMinutes, rawValue)
+        }
+    }
+}
+
+class PasscodeKitInterval: UIViewController {
     
     fileprivate let tableView = UITableView(frame: .zero, style: .insetGrouped)
-    fileprivate var selectedRow = 0
+    
+    private var selectedRow = 0
+    
+    var delegate: PasscodeKitDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,7 +59,7 @@ class IntervalViewController: UIViewController {
     }
 }
 
-extension IntervalViewController: UITableViewDataSource {
+extension PasscodeKitInterval: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return PasscodeInterval.allCases.count
     }
@@ -55,10 +77,11 @@ extension IntervalViewController: UITableViewDataSource {
     }
 }
 
-extension IntervalViewController: UITableViewDelegate {
+extension PasscodeKitInterval: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         PasscodeKit.passcodeInterval(PasscodeInterval.allCases[indexPath.item].rawValue)
+        delegate?.passcodeIntervalChanged?()
         
         selectedRow = indexPath.row
         tableView.reloadData()

--- a/PasscodeKit/Sources/PasscodeKitVerify.swift
+++ b/PasscodeKit/Sources/PasscodeKitVerify.swift
@@ -51,7 +51,7 @@ extension PasscodeKitVerify {
 		let context = LAContext()
 
 		if (PasscodeKit.biometric()) && (context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {
-			let reason = PasscodeKit.textTouchIDAccessReason
+			let reason = PasscodeKit.textBiometricAccessReason
 			context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason) { success, error in
 				DispatchQueue.main.async {
 					self.actionBiometric(success)

--- a/PasscodeKit/app.xcodeproj/project.pbxproj
+++ b/PasscodeKit/app.xcodeproj/project.pbxproj
@@ -20,8 +20,7 @@
 		29D9780C261DB37700C80DBD /* PasscodeKitRemove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */; };
 		29D97810261DB39C00C80DBD /* PasscodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D9780E261DB39C00C80DBD /* PasscodeView.swift */; };
 		29D97811261DB39C00C80DBD /* PasscodeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29D9780F261DB39C00C80DBD /* PasscodeView.xib */; };
-		4D200CAE28831CE700C8DF4D /* IntervalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D200CAD28831CE700C8DF4D /* IntervalView.swift */; };
-		4D200CB028831D0200C8DF4D /* PasscodeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */; };
+		4D200CB028831D0200C8DF4D /* PasscodeKitInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D200CAF28831D0200C8DF4D /* PasscodeKitInterval.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,8 +39,7 @@
 		29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeKitRemove.swift; sourceTree = "<group>"; };
 		29D9780E261DB39C00C80DBD /* PasscodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeView.swift; sourceTree = "<group>"; };
 		29D9780F261DB39C00C80DBD /* PasscodeView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PasscodeView.xib; sourceTree = "<group>"; };
-		4D200CAD28831CE700C8DF4D /* IntervalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntervalView.swift; sourceTree = "<group>"; };
-		4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeInterval.swift; sourceTree = "<group>"; };
+		4D200CAF28831D0200C8DF4D /* PasscodeKitInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeKitInterval.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,7 +62,7 @@
 				29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */,
 				29D97801261DB37700C80DBD /* PasscodeKitText.swift */,
 				29D97803261DB37700C80DBD /* PasscodeKitVerify.swift */,
-				4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */,
+				4D200CAF28831D0200C8DF4D /* PasscodeKitInterval.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -97,7 +95,6 @@
 				29D9780F261DB39C00C80DBD /* PasscodeView.xib */,
 				295B8481248C1C5B003E8AE6 /* ViewController.swift */,
 				295B8480248C1C5B003E8AE6 /* ViewController.xib */,
-				4D200CAD28831CE700C8DF4D /* IntervalView.swift */,
 			);
 			path = app;
 			sourceTree = "<group>";
@@ -187,12 +184,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				29D97809261DB37700C80DBD /* PasscodeKitVerify.swift in Sources */,
-				4D200CAE28831CE700C8DF4D /* IntervalView.swift in Sources */,
 				295B8483248C1C5B003E8AE6 /* ViewController.swift in Sources */,
 				29D9780C261DB37700C80DBD /* PasscodeKitRemove.swift in Sources */,
 				29D97807261DB37700C80DBD /* PasscodeKitText.swift in Sources */,
 				29D9780B261DB37700C80DBD /* PasscodeKitChange.swift in Sources */,
-				4D200CB028831D0200C8DF4D /* PasscodeInterval.swift in Sources */,
+				4D200CB028831D0200C8DF4D /* PasscodeKitInterval.swift in Sources */,
 				29D97808261DB37700C80DBD /* PasscodeKit.swift in Sources */,
 				29D97810261DB39C00C80DBD /* PasscodeView.swift in Sources */,
 				29D9780A261DB37700C80DBD /* PasscodeKitCreate.swift in Sources */,

--- a/PasscodeKit/app.xcodeproj/project.pbxproj
+++ b/PasscodeKit/app.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		29D9780C261DB37700C80DBD /* PasscodeKitRemove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */; };
 		29D97810261DB39C00C80DBD /* PasscodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D9780E261DB39C00C80DBD /* PasscodeView.swift */; };
 		29D97811261DB39C00C80DBD /* PasscodeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29D9780F261DB39C00C80DBD /* PasscodeView.xib */; };
+		4D200CAE28831CE700C8DF4D /* IntervalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D200CAD28831CE700C8DF4D /* IntervalView.swift */; };
+		4D200CB028831D0200C8DF4D /* PasscodeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +40,8 @@
 		29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeKitRemove.swift; sourceTree = "<group>"; };
 		29D9780E261DB39C00C80DBD /* PasscodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeView.swift; sourceTree = "<group>"; };
 		29D9780F261DB39C00C80DBD /* PasscodeView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PasscodeView.xib; sourceTree = "<group>"; };
+		4D200CAD28831CE700C8DF4D /* IntervalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntervalView.swift; sourceTree = "<group>"; };
+		4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeInterval.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +64,7 @@
 				29D97806261DB37700C80DBD /* PasscodeKitRemove.swift */,
 				29D97801261DB37700C80DBD /* PasscodeKitText.swift */,
 				29D97803261DB37700C80DBD /* PasscodeKitVerify.swift */,
+				4D200CAF28831D0200C8DF4D /* PasscodeInterval.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -92,6 +97,7 @@
 				29D9780F261DB39C00C80DBD /* PasscodeView.xib */,
 				295B8481248C1C5B003E8AE6 /* ViewController.swift */,
 				295B8480248C1C5B003E8AE6 /* ViewController.xib */,
+				4D200CAD28831CE700C8DF4D /* IntervalView.swift */,
 			);
 			path = app;
 			sourceTree = "<group>";
@@ -181,10 +187,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				29D97809261DB37700C80DBD /* PasscodeKitVerify.swift in Sources */,
+				4D200CAE28831CE700C8DF4D /* IntervalView.swift in Sources */,
 				295B8483248C1C5B003E8AE6 /* ViewController.swift in Sources */,
 				29D9780C261DB37700C80DBD /* PasscodeKitRemove.swift in Sources */,
 				29D97807261DB37700C80DBD /* PasscodeKitText.swift in Sources */,
 				29D9780B261DB37700C80DBD /* PasscodeKitChange.swift in Sources */,
+				4D200CB028831D0200C8DF4D /* PasscodeInterval.swift in Sources */,
 				29D97808261DB37700C80DBD /* PasscodeKit.swift in Sources */,
 				29D97810261DB39C00C80DBD /* PasscodeView.swift in Sources */,
 				29D9780A261DB37700C80DBD /* PasscodeKitCreate.swift in Sources */,

--- a/PasscodeKit/app/IntervalView.swift
+++ b/PasscodeKit/app/IntervalView.swift
@@ -1,0 +1,66 @@
+//
+//  IntervalViewController.swift
+//  Example
+//
+//  Created by StephenFang on 2022/7/8.
+//  Copyright © 2022 KZ. All rights reserved.
+//
+
+import UIKit
+
+class IntervalViewController: UIViewController {
+    
+    fileprivate let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    fileprivate var selectedRow = 0
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = "Require Password"
+        
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
+        
+        view.addSubview(tableView)
+        tableView.frame = view.bounds
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if let selectedRow = PasscodeInterval.allCases.firstIndex(where: { $0.rawValue == PasscodeKit.passcodeInterval()
+        }) {
+            self.selectedRow = selectedRow
+        }
+        tableView.selectRow(at: IndexPath(item: selectedRow, section: 0), animated: false, scrollPosition: .top)
+    }
+}
+
+extension IntervalViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return PasscodeInterval.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        var cell: UITableViewCell! = tableView.dequeueReusableCell(withIdentifier: "cell")
+        if (cell == nil) { cell = UITableViewCell(style: .default, reuseIdentifier: "cell") }
+
+        cell.selectionStyle = .none
+        cell.textLabel?.text = PasscodeInterval.allCases[indexPath.item].localizedDescription
+        cell.accessoryType = indexPath.row == selectedRow ? .checkmark : .none
+
+        return cell
+    }
+}
+
+extension IntervalViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        PasscodeKit.passcodeInterval(PasscodeInterval.allCases[indexPath.item].rawValue)
+        
+        selectedRow = indexPath.row
+        tableView.reloadData()
+    }
+}

--- a/PasscodeKit/app/PasscodeView.swift
+++ b/PasscodeKit/app/PasscodeView.swift
@@ -82,7 +82,7 @@ class PasscodeView: UIViewController {
             cellInterval.textLabel?.textColor = UIColor.lightGray
 		}
         
-        cellInterval.detailTextLabel?.text = PasscodeInterval.allCases.first(where: { $0.rawValue == PasscodeKit.passcodeInterval()})?.localizedDescription
+        cellInterval.detailTextLabel?.text = PasscodeKit.passcodeLocalizedInterval()
         
 		switchBiometric.isOn = PasscodeKit.biometric()
 

--- a/PasscodeKit/app/PasscodeView.swift
+++ b/PasscodeKit/app/PasscodeView.swift
@@ -61,9 +61,7 @@ class PasscodeView: UIViewController {
     func actionChangeInterval() {
 
         if (PasscodeKit.enabled()) {
-            
-            let intervalViewController = IntervalViewController()
-            navigationController?.pushViewController(intervalViewController, animated: true)
+            PasscodeKit.changeInterval(self.navigationController!)
         }
     }
 

--- a/PasscodeKit/app/PasscodeView.swift
+++ b/PasscodeKit/app/PasscodeView.swift
@@ -19,10 +19,10 @@ class PasscodeView: UIViewController {
 	@IBOutlet private var cellTurnPasscode: UITableViewCell!
 	@IBOutlet private var cellChangePasscode: UITableViewCell!
 	@IBOutlet private var cellBiometric: UITableViewCell!
+    @IBOutlet private var cellInterval: UITableViewCell!
+    @IBOutlet private var switchBiometric: UISwitch!
 
-	@IBOutlet private var switchBiometric: UISwitch!
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	override func viewDidLoad() {
 
 		super.viewDidLoad()
@@ -31,7 +31,7 @@ class PasscodeView: UIViewController {
 		switchBiometric.addTarget(self, action: #selector(actionBiometric), for: .valueChanged)
 	}
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
+
 	override func viewWillAppear(_ animated: Bool) {
 
 		super.viewWillAppear(animated)
@@ -40,7 +40,7 @@ class PasscodeView: UIViewController {
 	}
 
 	// MARK: - User actions
-	//-------------------------------------------------------------------------------------------------------------------------------------------
+
 	func actionTurnPasscode() {
 
 		if (PasscodeKit.enabled()) {
@@ -49,33 +49,43 @@ class PasscodeView: UIViewController {
 			PasscodeKit.createPasscode(self)
 		}
 	}
-
-	//-------------------------------------------------------------------------------------------------------------------------------------------
+    
 	func actionChangePasscode() {
 
 		if (PasscodeKit.enabled()) {
 			PasscodeKit.changePasscode(self)
 		}
 	}
+    
+    
+    func actionChangeInterval() {
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
+        if (PasscodeKit.enabled()) {
+            
+            let intervalViewController = IntervalViewController()
+            navigationController?.pushViewController(intervalViewController, animated: true)
+        }
+    }
+
 	@objc func actionBiometric() {
-
 		PasscodeKit.biometric(switchBiometric.isOn)
 	}
 
 	// MARK: - Helper methods
-	//-------------------------------------------------------------------------------------------------------------------------------------------
-	func updateViewDetails() {
 
+	func updateViewDetails() {
 		if (PasscodeKit.enabled()) {
 			cellTurnPasscode.textLabel?.text = "Turn Passcode Off"
 			cellChangePasscode.textLabel?.textColor = UIColor.systemBlue
+            cellInterval.textLabel?.textColor = UIColor.systemBlue
 		} else {
 			cellTurnPasscode.textLabel?.text = "Turn Passcode On"
 			cellChangePasscode.textLabel?.textColor = UIColor.lightGray
+            cellInterval.textLabel?.textColor = UIColor.lightGray
 		}
-
+        
+        cellInterval.detailTextLabel?.text = PasscodeInterval.allCases.first(where: { $0.rawValue == PasscodeKit.passcodeInterval()})?.localizedDescription
+        
 		switchBiometric.isOn = PasscodeKit.biometric()
 
 		tableView.reloadData()
@@ -83,53 +93,40 @@ class PasscodeView: UIViewController {
 }
 
 // MARK: - UITableViewDataSource
-//-----------------------------------------------------------------------------------------------------------------------------------------------
+
 extension PasscodeView: UITableViewDataSource {
-
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	func numberOfSections(in tableView: UITableView) -> Int {
-
-		return PasscodeKit.enabled() ? 2 : 1
+		return PasscodeKit.enabled() ? 3 : 1
 	}
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
 		if (section == 0) { return 2 }
-		if (section == 1) { return 1 }
-
+        if (section == 1) { return 1 }
+		if (section == 2) { return 1 }
 		return 0
 	}
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-
-		if (section == 1) { return "Allow to use Face ID (or Touch ID) to unlock the app." }
-
+        if (section == 2) { return PasscodeKit.textBiometricAccessTip }
 		return nil
 	}
 
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-
 		if (indexPath.section == 0) && (indexPath.row == 0) { return cellTurnPasscode	}
 		if (indexPath.section == 0) && (indexPath.row == 1) { return cellChangePasscode	}
-		if (indexPath.section == 1) && (indexPath.row == 0) { return cellBiometric		}
-
+        if (indexPath.section == 1) && (indexPath.row == 0) { return cellInterval    }
+		if (indexPath.section == 2) && (indexPath.row == 0) { return cellBiometric		}
 		return UITableViewCell()
 	}
 }
 
 // MARK: - UITableViewDelegate
-//-----------------------------------------------------------------------------------------------------------------------------------------------
+
 extension PasscodeView: UITableViewDelegate {
-
-	//-------------------------------------------------------------------------------------------------------------------------------------------
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-
 		tableView.deselectRow(at: indexPath, animated: true)
-
 		if (indexPath.section == 0) && (indexPath.row == 0) { actionTurnPasscode()		}
 		if (indexPath.section == 0) && (indexPath.row == 1) { actionChangePasscode()	}
+        if (indexPath.section == 1) && (indexPath.row == 0) { actionChangeInterval()    }
 	}
 }

--- a/PasscodeKit/app/PasscodeView.xib
+++ b/PasscodeKit/app/PasscodeView.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21208.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21191"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +13,7 @@
             <connections>
                 <outlet property="cellBiometric" destination="3rd-tQ-elY" id="j9O-HW-ppz"/>
                 <outlet property="cellChangePasscode" destination="2Tc-5l-EBC" id="eX0-Ga-8FT"/>
+                <outlet property="cellInterval" destination="Mxw-Uz-UEz" id="Cjf-B4-lix"/>
                 <outlet property="cellTurnPasscode" destination="DAM-D6-xJS" id="TAi-O6-JmK"/>
                 <outlet property="switchBiometric" destination="GfW-am-9uq" id="aC8-zX-jBa"/>
                 <outlet property="tableView" destination="i5M-Pr-FkT" id="qQ3-TI-f3b"/>
@@ -57,7 +59,7 @@
                     </label>
                 </subviews>
             </tableViewCellContentView>
-            <point key="canvasLocation" x="415" y="-208"/>
+            <point key="canvasLocation" x="414.375" y="-208.09859154929578"/>
         </tableViewCell>
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="JeA-lO-05V" style="IBUITableViewCellStyleDefault" id="2Tc-5l-EBC">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
@@ -92,7 +94,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GfW-am-9uq">
-                        <rect key="frame" x="246" y="9.5" width="51" height="31"/>
+                        <rect key="frame" x="246" y="9.6666666666666643" width="51" height="31"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="49" id="1iu-mu-hec"/>
                             <constraint firstAttribute="height" constant="31" id="hfx-cB-YhN"/>
@@ -106,10 +108,38 @@
             </tableViewCellContentView>
             <point key="canvasLocation" x="415" y="-6"/>
         </tableViewCell>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="3CE-cx-FGO" detailTextLabel="YnI-NT-sT0" style="IBUITableViewCellStyleValue1" id="Mxw-Uz-UEz">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Mxw-Uz-UEz" id="ahH-1u-eLb">
+                <rect key="frame" x="0.0" y="0.0" width="293.5" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Require Passcode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3CE-cx-FGO">
+                        <rect key="frame" x="16" y="13" width="130" height="19.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="YnI-NT-sT0">
+                        <rect key="frame" x="243.5" y="13" width="42" height="19.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="474.375" y="92.957746478873247"/>
+        </tableViewCell>
     </objects>
     <resources>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+## DIFFERENCES
+
+1. Added support for 'Require Passcode'
+   <img src="http://image.stephenfang.me/interval.png" height="300">
+   <img src="http://image.stephenfang.me/newPasscode.png" height="300">
+
+2. Added UINavigationBarAppearance support for iOS15
+   <img src="http://image.stephenfang.me/navBar.png" height="300">
+   <img src="http://image.stephenfang.me/Xnip2022-06-15_21-22-08.png" height="300">
+
+   Before / After
+
+3. Refined localization strings
+
+- Changed 'textTouchIDAccessReason' to 'textBiometricAccessReason'
+- Added 'textBiometricAccessTip'
+
 ## OVERVIEW
 
 PasscodeKit is a lightweight and easy-to-use, in-app Passcode implementation for iOS.
@@ -11,7 +28,7 @@ PasscodeKit is a lightweight and easy-to-use, in-app Passcode implementation for
 To use PasscodeKit with [CocoaPods](https://cocoapods.org), specify in your Podfile:
 
 ```ruby
-pod 'PasscodeKit'
+pod 'PasscodeKit', :git => 'https://github.com/iamStephenFang/PasscodeKit.git', :branch => 'master'
 ```
 
 ### Manually
@@ -24,7 +41,7 @@ If you prefer not to use any of the dependency managers, you can integrate `Pass
 
 ## QUICKSTART
 
-To activate the PasscodeKit in your codebase, you need to start it right after the app is launched. The best practice to do it in the AppDelegate `didFinishLaunchingWithOptions` method. 
+To activate the PasscodeKit in your codebase, you need to start it right after the app is launched. The best practice to do it in the AppDelegate `didFinishLaunchingWithOptions` method.
 
 ```swift
 PasscodeKit.start()
@@ -51,6 +68,12 @@ PasscodeKit.removePasscode(self)
 ```
 
 <img src="https://related.chat/passcodekit/02x.png" width="880">
+
+The following `PasscodeKitDelegate` methods can be used to receive notifications when the password interval is changed.
+
+```swift
+func passcodeIntervalChanged()
+```
 
 ## CUSTOMIZATION
 
@@ -83,7 +106,14 @@ PasscodeKit.textEnterNewPasscode = "Enter your new passcode"
 PasscodeKit.textVerifyNewPasscode = "Verify your new passcode"
 PasscodeKit.textFailedPasscode = "%d Failed Passcode Attempts"
 PasscodeKit.textPasscodeMismatch = "Passcodes did not match. Try again."
-PasscodeKit.textTouchIDAccessReason = "Please use Touch ID to unlock the app"
+PasscodeKit.textBiometricAccessReason = "Please use Touch ID to unlock the app"
+PasscodeKit.textBiometricAccessTip = "Allow to use Face ID (or Touch ID) to unlock the app"
+```
+
+```swift
+PasscodeKit.vefifyPasscodeImmediately  = "Immediately"
+PasscodeKit.vefifyPasscodeAfterMinutes = "After %.f minutes"
+PasscodeKit.vefifyPasscodeAfterOneHour = "After an hour"
 ```
 
 ## CONFIGURATION
@@ -95,6 +125,26 @@ PasscodeKit supports both TouchID and FaceID. If you're using FaceID, be sure to
 ## LICENSE
 
 MIT License
+
+Copyright (c) 2022 StephenFang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 Copyright (c) 2021 Related Code
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 ## DIFFERENCES
 
 1. Added support for 'Require Passcode'
-   <img src="http://image.stephenfang.me/interval.png" height="300">
-   <img src="http://image.stephenfang.me/newPasscode.png" height="300">
+
+   <img src="http://image.stephenfang.me/interval.png" height="400">
+   <img src="http://image.stephenfang.me/newPasscode.png" height="400">
 
 2. Added UINavigationBarAppearance support for iOS15
-   <img src="http://image.stephenfang.me/navBar.png" height="300">
-   <img src="http://image.stephenfang.me/Xnip2022-06-15_21-22-08.png" height="300">
 
-   Before / After
+   (Before & After)
+
+   <img src="http://image.stephenfang.me/navBar.png" height="400">
+   <img src="http://image.stephenfang.me/passdemo.png" height="400">
+   
+   Also see [PR](https://github.com/relatedcode/PasscodeKit/pull/2) here.
 
 3. Refined localization strings
 


### PR DESCRIPTION
# Description

In iOS 15, UIKit has extended the usage of the scrollEdgeAppearance, which by default produces a transparent background, to all navigation bars." To restore the old look, you must adopt the new UINavigationBar appearance APIs.

Also see [issue](https://developer.apple.com/forums/thread/683265) here.

Fixes # Navigation Bar Behaviors on iOS 15

## Type of change

- [x] Bug fix 

# How Has This Been Tested?

- Previous Password UI
![Previous Password UI](http://image.stephenfang.me/Xnip2022-06-15_21-24-00.png)
	
- Current Password UI
![Current Password UI](http://image.stephenfang.me/passdemo.png)

**Test Configuration**:
* Firmware version: PasscodeKit v1.0.1
* Hardware: iPhone SE 3rd gen Simulator 
* Toolchain: Xcode & Lookin
* SDK: iOS 15.5

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings